### PR TITLE
FIX: Errors in HistoryRoutes, History and Project Controllers, and History and Project Models

### DIFF
--- a/server/controllers/historyControllers.ts
+++ b/server/controllers/historyControllers.ts
@@ -11,6 +11,7 @@ export const getAllProjectVersions = async (req: Request, res: Response) => {
     const project = await Project.findById(projectId);
     if (!project) {
       res.status(404).json({ message: "Project not found" });
+      return;
     }
 
     // Fetch versions for the project
@@ -30,9 +31,10 @@ export const createProjectVersion = async (req: Request, res: Response) => {
     const { name, description } = req.body;
 
     if (!name) {
-      return res.status(400).json({
+      res.status(400).json({
         message: "Version name is required. Example: 1.0 or Dev Branch",
       });
+      return;
     }
 
     // Check if version already exists for this project
@@ -42,7 +44,7 @@ export const createProjectVersion = async (req: Request, res: Response) => {
     });
 
     if (existingVersion) {
-      return res.status(409).json({
+      res.status(409).json({
         message: "Version with this name already exists for this project.",
       });
     }
@@ -53,9 +55,9 @@ export const createProjectVersion = async (req: Request, res: Response) => {
       description,
     });
 
-    return res.status(201).json(newVersion);
+    res.status(201).json(newVersion);
   } catch (err: any) {
-    return res.status(500).json({
+    res.status(500).json({
       message: "Failed to create version",
       error: err.message,
     });
@@ -74,6 +76,7 @@ export const getVersionById = async (req: Request, res: Response) => {
     }).populate("project");
     if (!version) {
       res.status(404).json({ message: "Version not found" });
+      return;
     }
 
     res.status(200).json(version);
@@ -94,7 +97,8 @@ export const editProjectVersion = async (req: Request, res: Response) => {
     const { name, description } = req.body;
 
     if (!versionId) {
-      return res.status(400).json({ message: "Version ID is required." });
+      res.status(400).json({ message: "Version ID is required." });
+      return;
     }
 
     const updates: Partial<EditProjectVersionBody> = {};
@@ -107,12 +111,13 @@ export const editProjectVersion = async (req: Request, res: Response) => {
     });
 
     if (!updatedVersion) {
-      return res.status(404).json({ message: "Version not found." });
+      res.status(404).json({ message: "Version not found." });
+      return;
     }
 
-    return res.status(200).json(updatedVersion);
+    res.status(200).json(updatedVersion);
   } catch (err: any) {
-    return res.status(500).json({
+    res.status(500).json({
       message: err instanceof Error ? err.message : "An error occurred.",
     });
   }
@@ -125,12 +130,13 @@ export const deleteProjectVersion = async (req: Request, res: Response) => {
 
     const deletedVersion = await Version.findByIdAndDelete(versionId);
     if (!deletedVersion) {
-      return res.status(404).json({ message: "Version not found." });
+      res.status(404).json({ message: "Version not found." });
+      return;
     }
 
-    return res.status(200).json({ message: "Version deleted successfully." });
+    res.status(200).json({ message: "Version deleted successfully." });
   } catch (err: any) {
-    return res.status(500).json({ message: err.message });
+    res.status(500).json({ message: err.message });
   }
 };
 
@@ -143,6 +149,7 @@ export const getVersionHistory = async (req: Request, res: Response) => {
     const version = await Version.findById(versionId);
     if (!version) {
       res.status(404).json({ message: "Version not found" });
+      return;
     }
 
     // Fetch history entries for the version
@@ -162,7 +169,8 @@ export const createVersionHistory = async (req: Request, res: Response) => {
     const { data, members } = req.body;
 
     if (!data) {
-      return res.status(400).json({ message: "Data is required." });
+      res.status(400).json({ message: "Data is required." });
+      return;
     }
 
     const newHistory = await History.create({
@@ -183,12 +191,13 @@ export const createVersionHistory = async (req: Request, res: Response) => {
     );
 
     if (!updatedVersion) {
-      return res.status(404).json({ message: "Version not found." });
+      res.status(404).json({ message: "Version not found." });
+      return;
     }
 
-    return res.status(201).json(newHistory);
+    res.status(201).json(newHistory);
   } catch (err: any) {
-    return res.status(500).json({ message: err.message });
+    res.status(500).json({ message: err.message });
   }
 };
 
@@ -204,6 +213,7 @@ export const getHistoryById = async (req: Request, res: Response) => {
     }).populate("version");
     if (!history) {
       res.status(404).json({ message: "History entry not found" });
+      return;
     }
 
     res.status(200).json(history);
@@ -224,7 +234,8 @@ export const editVersionHistory = async (req: Request, res: Response) => {
     const { data, members } = req.body;
 
     if (!historyId) {
-      return res.status(400).json({ message: "History ID is required." });
+      res.status(400).json({ message: "History ID is required." });
+      return;
     }
 
     const updates: Partial<EditVersionHistoryBody> = {};
@@ -236,13 +247,14 @@ export const editVersionHistory = async (req: Request, res: Response) => {
     });
 
     if (!updatedHistory) {
-      return res.status(404).json({ message: "History entry not found." });
+      res.status(404).json({ message: "History entry not found." });
+      return;
     }
 
-    return res.status(200).json(updatedHistory);
+    res.status(200).json(updatedHistory);
   } catch (err: any) {
     console.error(err);
-    return res.status(500).json({ message: err.message });
+    res.status(500).json({ message: err.message });
   }
 };
 
@@ -252,53 +264,42 @@ export const deleteVersionHistory = async (req: Request, res: Response) => {
     const { historyId } = req.params;
 
     if (!historyId) {
-      return res.status(400).json({ message: "History ID is required." });
+      res.status(400).json({ message: "History ID is required." });
+      return;
     }
 
     const historyToDelete = await History.findById(historyId);
 
     if (!historyToDelete) {
-      return res.status(404).json({ message: "History entry not found." });
+      res.status(404).json({ message: "History entry not found." });
+      return;
     }
 
-    await deleteHistoriesAfter(req, res, historyId);
+    const deleteMessage = await deleteHistoriesAfter(historyId);
 
     await History.findByIdAndDelete(historyId);
 
-    return res
+    res
       .status(200)
-      .json({ message: "History entry deleted successfully." });
+      .json({ message: "History entry deleted successfully.", deleteMessage });
   } catch (err: any) {
-    return res.status(500).json({ message: err.message });
+    res.status(500).json({ message: err.message });
   }
 };
 
 // Delete all history entries after a specific history
-export const deleteHistoriesAfter = async (req: Request, res: Response) => {
-  try {
-    const { historyId } = req.params;
+const deleteHistoriesAfter = async (historyId: string): Promise<string> => {
+  const referenceHistory = await History.findById(historyId);
 
-    if (!historyId) {
-      return res.status(400).json({ message: "History ID is required." });
-    }
-
-    const referenceHistory = await History.findById(historyId);
-    if (!referenceHistory) {
-      return res
-        .status(404)
-        .json({ message: "Reference history entry not found." });
-    }
-
+  if (referenceHistory) {
     const deletedHistories = await History.deleteMany({
       version: referenceHistory.version,
       createdAt: { $gt: referenceHistory.createdAt },
     });
 
-    return res.status(200).json({
-      message: `${deletedHistories.deletedCount} histories deleted.`,
-    });
-  } catch (err: any) {
-    return res.status(500).json({ message: err.message });
+    return `${deletedHistories.deletedCount} histories deleted.`;
+  } else {
+    throw new Error("Reference history entry not found.");
   }
 };
 
@@ -309,36 +310,38 @@ export const rollbackVersionToHistory = async (req: Request, res: Response) => {
   try {
     // Find the history entry by ID
     const originalHistory = await History.findById(historyId);
-    if (!originalHistory) {
-      return res.status(404).json({ message: "History entry not found." });
-    }
+    if (originalHistory) {
+      // Create a new history entry based on the original one
+      const rollbackEntry = await History.create({
+        version: versionId,
+        data: originalHistory.data,
+        members: originalHistory.members,
+        isRollback: true,
+      });
 
-    // Create a new history entry based on the original one
-    const rollbackEntry = await History.create({
-      version: versionId,
-      data: originalHistory.data,
-      members: originalHistory.members,
-      isRollback: true,
-    });
+      const updatedVersion = await Version.findByIdAndUpdate(
+        versionId,
+        { currentHistory: rollbackEntry._id },
+        { new: true }
+      );
+
+      if (!updatedVersion) {
+        res.status(404).json({ message: "Version not found." });
+        return;
+      }
+
+      res.status(200).json({
+        message: "Version rolled back successfully.",
+        version: updatedVersion,
+        rollbackEntry,
+      });
+    } else {
+      res.status(404).json({ message: "History entry not found." });
+    }
 
     // Update the version's current history reference
-    const updatedVersion = await Version.findByIdAndUpdate(
-      versionId,
-      { currentHistory: rollbackEntry._id },
-      { new: true }
-    );
-
-    if (!updatedVersion) {
-      return res.status(404).json({ message: "Version not found." });
-    }
-
-    return res.status(200).json({
-      message: "Version rolled back successfully.",
-      version: updatedVersion,
-      rollbackEntry,
-    });
   } catch (error: any) {
-    return res.status(500).json({
+    res.status(500).json({
       message: "Error during rollback: " + error.message,
     });
   }

--- a/server/models/historyModel.ts
+++ b/server/models/historyModel.ts
@@ -3,7 +3,7 @@ import mongoose from "mongoose";
 // Define the Version schema
 const versionSchema = new mongoose.Schema(
   {
-    version: { type: String, required: true, trim: true }, // Example: "1.0.0"
+    name: { type: String, required: true, trim: true }, // Example: "1.0.0"
     description: { type: String, required: false, trim: true }, // Optional metadata about the version
     project: {
       type: mongoose.Schema.Types.ObjectId,
@@ -14,7 +14,7 @@ const versionSchema = new mongoose.Schema(
     currentHistory: {
       type: mongoose.Schema.Types.ObjectId,
       ref: "History",
-    }, 
+    },
   },
   {
     timestamps: true, // Automatically adds createdAt and updatedAt fields
@@ -44,10 +44,9 @@ const historySchema = new mongoose.Schema(
         required: false,
       },
     ],
-    changeType: {
-      type: String,
-      enum: ["CREATE", "UPDATE", "DELETE", "ROLLBACK"],
-      required: true,
+    isRollback: {
+      type: Boolean,
+      default: false,
     },
   },
   {

--- a/server/models/historyModel.ts
+++ b/server/models/historyModel.ts
@@ -113,13 +113,17 @@ versionSchema.pre("deleteMany", async function (next) {
     }
 
     next();
-  } catch (error) {
-    next(error);
+  } catch (error: any) {
+    if (error instanceof Error) {
+      next(error);
+    } else {
+      next(new Error("Unknown error"));
+    }
   }
 });
 
 // Middleware for findByIdAndDelete operations
-versionSchema.pre("findByIdAndDelete", async function (next) {
+versionSchema.pre("findOneAndDelete", async function (next) {
   try {
     const doc = await this.model.findOne(this.getFilter());
     if (doc) {
@@ -127,7 +131,11 @@ versionSchema.pre("findByIdAndDelete", async function (next) {
     }
     next();
   } catch (error) {
-    next(error);
+    if (error instanceof Error) {
+      next(error);
+    } else {
+      next(new Error("Unknown error"));
+    }
   }
 });
 

--- a/server/models/projectModel.ts
+++ b/server/models/projectModel.ts
@@ -19,27 +19,30 @@ const projectSchema = new mongoose.Schema(
 );
 
 // Middleware to cascade the deleting of projects and versions
-projectSchema.pre(['findOneAndDelete', 'findByIdAndDelete'], async function(next) {
+projectSchema.pre("findOneAndDelete", async function (next) {
   try {
     // Get the document that's about to be deleted
     const doc = await this.model.findOne(this.getFilter());
     if (doc) {
       // Find all versions associated with this project
       const versions = await Version.find({ project: doc._id });
-      const versionIds = versions.map(version => version._id);
-      
+      const versionIds = versions.map((version) => version._id);
+
       // Delete all associated histories
       await History.deleteMany({ version: { $in: versionIds } });
-      
+
       // Delete all versions
       await Version.deleteMany({ project: doc._id });
     }
     next();
   } catch (error) {
-    next(error);
+    if (error instanceof Error) {
+      next(error);
+    } else {
+      next(new Error("Unknown error"));
+    }
   }
 });
-
 
 // Create a model
 const Project = mongoose.model("Project", projectSchema);

--- a/server/models/projectModel.ts
+++ b/server/models/projectModel.ts
@@ -1,4 +1,5 @@
 import mongoose from "mongoose";
+import { History, Version } from "./historyModel";
 
 // Define a schema
 const projectSchema = new mongoose.Schema(
@@ -16,6 +17,29 @@ const projectSchema = new mongoose.Schema(
     timestamps: true,
   }
 );
+
+// Middleware to cascade the deleting of projects and versions
+projectSchema.pre(['findOneAndDelete', 'findByIdAndDelete'], async function(next) {
+  try {
+    // Get the document that's about to be deleted
+    const doc = await this.model.findOne(this.getFilter());
+    if (doc) {
+      // Find all versions associated with this project
+      const versions = await Version.find({ project: doc._id });
+      const versionIds = versions.map(version => version._id);
+      
+      // Delete all associated histories
+      await History.deleteMany({ version: { $in: versionIds } });
+      
+      // Delete all versions
+      await Version.deleteMany({ project: doc._id });
+    }
+    next();
+  } catch (error) {
+    next(error);
+  }
+});
+
 
 // Create a model
 const Project = mongoose.model("Project", projectSchema);

--- a/server/routes/historyRoutes.ts
+++ b/server/routes/historyRoutes.ts
@@ -18,20 +18,22 @@ import {
 const router = express.Router();
 
 // Define routes
-router.get("/:id/v", getAllProjectVersions);
-router.get("/:id/v/:versionId", getVersionById);
-router.get("/:id/v/:versionId/h", getVersionHistory);
-router.get("/:id/v/:versionId/h/:historyId", getHistoryById);
+// Version routes
+router.get("/:projectId/version", getAllProjectVersions);
+router.post("/:projectId/version", encryptDataMiddleware, createProjectVersion);
+router.get("/:projectId/version/:versionId", getVersionById);
+router.patch("/:projectId/version/:versionId", encryptDataMiddleware, editProjectVersion);
+router.delete("/:projectId/version/:versionId", deleteProjectVersion);
 
-router.post("/:id/v", encryptDataMiddleware, createProjectVersion);
-router.patch("/:id/v", encryptDataMiddleware, editProjectVersion);
-router.delete("/:id/v", deleteProjectVersion);
+// Version history routes
+router.get("/:projectId/version/:versionId/history", getVersionHistory);
+router.post("/:projectId/version/:versionId/history", encryptDataMiddleware, createVersionHistory);
+router.get("/:projectId/version/:versionId/history/:historyId", getHistoryById);
+router.patch("/:projectId/version/:versionId/history/:historyId", encryptDataMiddleware, editVersionHistory);
+router.delete("/:projectId/version/:versionId/history/:historyId", deleteVersionHistory);
 
-router.post("/:id/v/:versionId/h/:historyId/rb", rollbackVersionToHistory);
-
-router.post("/:id/h", encryptDataMiddleware, createVersionHistory);
-router.patch("/:id/h", encryptDataMiddleware, editVersionHistory);
-router.delete("/:id/h", deleteVersionHistory);
-router.delete("/:id/h/aft", deleteHistoriesAfter);
+// Special operations
+router.post("/:projectId/version/:versionId/history/:historyId/rollback", rollbackVersionToHistory);
+router.delete("/:projectId/version/:versionId/history/:historyId/after", deleteHistoriesAfter);
 
 export default router;

--- a/server/routes/historyRoutes.ts
+++ b/server/routes/historyRoutes.ts
@@ -3,7 +3,6 @@ import express from "express";
 import {
   createProjectVersion,
   createVersionHistory,
-  deleteHistoriesAfter,
   deleteProjectVersion,
   deleteVersionHistory,
   editProjectVersion,
@@ -34,6 +33,5 @@ router.delete("/:projectId/version/:versionId/history/:historyId", deleteVersion
 
 // Special operations
 router.post("/:projectId/version/:versionId/history/:historyId/rollback", rollbackVersionToHistory);
-router.delete("/:projectId/version/:versionId/history/:historyId/after", deleteHistoriesAfter);
 
 export default router;


### PR DESCRIPTION
Current Updates

Resolved issue from the previous PR:
- Transferred return statements on the validations after the response to ensure that no further code is executed
- Switched to positive if-else statements to check for null values for some functions in the controllers
- used findOneAndDelete in the middleware for cascading delete instead of findByIdAndDelete. As per mongoDB it should still work for findByIdAndDelete in the controller.
- Removed historyId and modified deleteHistoriesAfter

Previous Pull Request:
Added middleware to handle cascading the deletion of entries.
This ensures that all project related data is dependent on the projects existence.
- Project: This deletes versions and histories associated with the project.
- Version and History: This deletes histories associated with the version.

Version: changed 'version' to 'name' for better readability
History: removed 'changeType' and added 'isRollback'

- Updated history routes for better readability
- Updated history controllers to reflect updates in the route and schema