### PR TITLE
 Enhance Role-Based Access Control in Share Modal

### DIFF
--- a/server/types/memberTypes.ts
+++ b/server/types/memberTypes.ts
@@ -1,44 +1,43 @@
-import { Schema } from "mongoose"
-
+import { Schema } from "mongoose";
 
 // Types
-type MemberRole = 'owner' | 'admin' | 'editor' | 'viewer'
+type MemberRole = "owner" | "admin" | "editor" | "viewer";
 
 // Model
 export interface MemberModel {
-  projectId: Schema.Types.ObjectId
-  members: MemberUser[]
+  projectId: Schema.Types.ObjectId;
+  members: MemberUser[];
 }
 
 export interface MemberUser {
-  userId: Schema.Types.ObjectId
-  role: MemberRole
+  userId: Schema.Types.ObjectId;
+  role: MemberRole;
 }
 
 // Params and Request
 export interface ProjectParams {
-  projectId: string
+  projectId: string;
 }
 
 export interface MemberParams extends ProjectParams {
-  userId: string
+  userId: string;
 }
 
-
 export interface MemberBody {
-  userId: string,
-  role?: MemberRole
+  userId: string;
+  role?: MemberRole;
+  email: string;
 }
 
 export interface MemberRoleBody {
-  role: MemberRole
+  role: MemberRole;
 }
 
 // Response
 export interface MembersResponse {
-  id: string
-  username: string
-  email: string
-  displayName: string
-  role: MemberRole
+  id: string;
+  username: string;
+  email: string;
+  displayName: string;
+  role: MemberRole;
 }

--- a/src/components/modals/ShareModal.tsx
+++ b/src/components/modals/ShareModal.tsx
@@ -103,12 +103,6 @@ function ShareModal({ context, id }: ContextModalProps) {
       }
     };
 
-    if (!projectMembers[selectedProject.id]) {
-      loadMembers();
-    } else {
-      setLocalMembers(projectMembers[selectedProject.id]);
-    }
-
     loadMembers();
   }, [selectedProject?.id]);
 

--- a/src/components/modals/ShareModal.tsx
+++ b/src/components/modals/ShareModal.tsx
@@ -30,7 +30,7 @@ import useMemberRepo from "../../data/repo/useMemberRepo";
 import { showNotification } from "@mantine/notifications";
 import useUserRepo from "../../data/repo/useUserRepo";
 
-function ShareModal({ context, id, innerProps }: ContextModalProps) {
+function ShareModal({ context, id }: ContextModalProps) {
   const { user } = useUserRepo();
   const { selectedProject } = useProjectRepo();
   const {
@@ -48,29 +48,41 @@ function ShareModal({ context, id, innerProps }: ContextModalProps) {
   const [initialLoading, setInitialLoading] = useState(true);
   const [isAddingMember, setIsAddingMember] = useState(false);
 
+  // useState to keep track project members locally.
+  const [localMembers, setLocalMembers] = useState<IProjectMembers[]>([]);
+
+  // Update local members whenever project members changes or the seleted projected changes
   useEffect(() => {
+    if (selectedProject?.id && projectMembers[selectedProject.id]) {
+      setLocalMembers(projectMembers[selectedProject.id]);
+    }
+  }, [selectedProject?.id, projectMembers]);
+
+  useEffect(() => {
+    if (!selectedProject) return;
+
     context.updateModal({
       modalId: id,
       title: (
         <Group gap="xs">
-          {selectedProject?.icon && (
+          {selectedProject.icon && (
             <Avatar src={selectedProject.icon} size="sm" />
           )}
           <Text fw={700} size="xl">
-            {selectedProject?.name || "Share Project"}
+            {selectedProject.name || "Share Project"}
           </Text>
         </Group>
       ),
       size: "md",
       centered: false,
     });
-  }, [selectedProject]);
+  }, [selectedProject?.id]); // Only run when project ID changes
 
   // Fetch members when the modal opens and selectedProject changes
   useEffect(() => {
-    const loadMembers = async () => {
-      if (!selectedProject?.id) return;
+    if (!selectedProject?.id) return;
 
+    const loadMembers = async () => {
       try {
         setInitialLoading(true);
         await fetchProjectMembers(selectedProject.id);
@@ -86,6 +98,12 @@ function ShareModal({ context, id, innerProps }: ContextModalProps) {
       }
     };
 
+    if (!projectMembers[selectedProject.id]) {
+      loadMembers();
+    } else {
+      setLocalMembers(projectMembers[selectedProject.id]);
+    }
+
     loadMembers();
   }, [selectedProject?.id]);
 
@@ -98,96 +116,99 @@ function ShareModal({ context, id, innerProps }: ContextModalProps) {
       });
       return;
     }
+    const displayName = newMemberEmail.split("@")[0];
+
+    const newMember: IProjectMembers = {
+      id: `temp-${Date.now()}`, // Use temp Id
+      username: newMemberEmail,
+      profileUrl: "",
+      email: newMemberEmail,
+      role: newMemberRole,
+      displayName: displayName,
+    };
+
+    setLocalMembers((prev) => [...prev, newMember]);
+    setNewMemberEmail("");
+    setShowAddMember(false);
+  };
+
+  const handleUpdateRole = (memberId: string, newRole: string) => {
+    setLocalMembers((prev) =>
+      prev.map((member) =>
+        member.id === memberId ? { ...member, role: newRole } : member
+      )
+    );
+  };
+
+  const handleRemoveMember = (memberId: string) => {
+    setLocalMembers((prev) => prev.filter((member) => member.id !== memberId));
+  };
+
+  const handleSave = async () => {
+    if (!selectedProject?.id) return;
 
     try {
-      setIsAddingMember(true);
-      await addProjectMember(selectedProject.id, newMemberEmail, newMemberRole);
+      setInitialLoading(true);
+
+      const currentMembers = projectMembers[selectedProject.id] || [];
+
+      const addedMembers = localMembers.filter((member) =>
+        member.id.startsWith("temp-")
+      );
+
+      const removedMembers = currentMembers.filter(
+        (member) => !localMembers.some((m) => m.email === member.email)
+      );
+
+      const roleUpdatedMembers = localMembers.filter((member) => {
+        const original = currentMembers.find((m) => m.id === member.id);
+        return original && original.role !== member.role;
+      });
+
+      // Batch API Calls Instead of Looping
+      await Promise.all([
+        ...addedMembers.map((member) =>
+          addProjectMember(selectedProject.id, member.email, member.role)
+        ),
+        ...removedMembers.map((member) =>
+          removeProjectMember(selectedProject.id, member.id)
+        ),
+        ...roleUpdatedMembers.map((member) =>
+          updateMemberRole(selectedProject.id, member.id, member.role)
+        ),
+      ]);
+
       await fetchProjectMembers(selectedProject.id);
-      setNewMemberEmail("");
-      setShowAddMember(false);
+
       showNotification({
         color: "green",
         title: "Success",
-        message: "Member added successfully",
+        message: "Changes saved successfully.",
       });
     } catch (error) {
-      console.error("Failed to add member:", error);
+      console.error("Failed to save changes:", error);
       showNotification({
         color: "red",
         title: "Error",
-        message: "Failed to add member. Please try again.",
+        message: "Failed to save changes. Please try again.",
       });
     } finally {
-      setIsAddingMember(false);
-    }
-  };
-
-  const handleUpdateRole = async (memberId: string, newRole: string) => {
-    if (!selectedProject?.id) return;
-
-    try {
-      await updateMemberRole(selectedProject.id, memberId, newRole);
-      await fetchProjectMembers(selectedProject.id);
-    } catch (error) {
-      console.error("Failed to update role:", error);
-      showNotification({
-        color: "red",
-        title: "Error",
-        message: "Failed to update role. Please try again.",
-      });
-    }
-  };
-
-  const handleRemoveMember = async (memberId: string) => {
-    if (!selectedProject?.id) return;
-
-    try {
-      await removeProjectMember(selectedProject.id, memberId);
-      await fetchProjectMembers(selectedProject.id);
-      showNotification({
-        color: "green",
-        title: "Success",
-        message:
-          memberId === user?.id
-            ? "You have left the project"
-            : "Member removed successfully",
-      });
-    } catch (error) {
-      console.error("Failed to remove member:", error);
-      showNotification({
-        color: "red",
-        title: "Error",
-        message:
-          memberId === user?.id
-            ? "Failed to remove yourself from the project"
-            : "Failed to remove member. Please try again.",
-      });
+      setInitialLoading(false);
     }
   };
 
   // Get members for the current project
   const members = useMemo(() => {
-    if (
-      !selectedProject?.id ||
-      !projectMembers ||
-      !projectMembers[selectedProject.id]
-    ) {
-      return [];
-    }
-
-    return projectMembers[selectedProject.id]
-      .filter(
-        (member: IProjectMembers | undefined): member is IProjectMembers =>
-          member !== undefined && member !== null
-      )
-      .map((member: IProjectMembers) => ({
+    return localMembers
+      .filter((member) => member !== undefined && member !== null)
+      .map((member) => ({
         id: member.id || "",
         profileUrl: member.profileUrl || "",
         name: member.displayName || "",
         email: member.email || "",
         role: member.role || "Viewer",
       }));
-  }, [selectedProject?.id, projectMembers]);
+  }, [localMembers]);
 
   return (
     <Box className="w-full h-full">
@@ -256,18 +277,22 @@ function ShareModal({ context, id, innerProps }: ContextModalProps) {
           <Center>
             <Loader size="sm" />
           </Center>
+        ) : members.length > 0 ? (
+          members.map((member) =>
+            member ? (
+              <MemberItem
+                key={member.id}
+                {...member}
+                isCurrentUser={member.id === user?.id}
+                onRoleChange={(newRole: string) =>
+                  handleUpdateRole(member.id, newRole)
+                }
+                onRemove={() => handleRemoveMember(member.id)}
+              />
+            ) : null
+          )
         ) : (
-          members.map((member) => (
-            <MemberItem
-              key={member.id}
-              {...member}
-              isCurrentUser={member.id === user?.id}
-              onRoleChange={(newRole: string) =>
-                handleUpdateRole(member.id, newRole)
-              }
-              onRemove={() => handleRemoveMember(member.id)}
-            />
-          ))
+          <Text>No members found.</Text>
         )}
       </Stack>
 
@@ -276,6 +301,16 @@ function ShareModal({ context, id, innerProps }: ContextModalProps) {
       </Title>
 
       <GeneralItem accessType="restricted" role="Viewer" />
+
+      <Button
+        variant="outline"
+        fullWidth={true}
+        mt={10}
+        loading={initialLoading}
+        onClick={handleSave}
+      >
+        Save
+      </Button>
     </Box>
   );
 }

--- a/src/data/api/membersApi.ts
+++ b/src/data/api/membersApi.ts
@@ -33,8 +33,8 @@ export const addProjectMemberApi = async (
 
     const response = await axiosInstance.post<APIResponse<CreatedProjectMember>>(
       `/projects/${projectId}/members`,
-      { email, role }
-    );
+       { email, role }
+      );
     console.log("addProjectMemberApi: Response:", response.data);
 
     return response.data;
@@ -77,7 +77,7 @@ export const updateProjectMemberRoleApi = async (
 ) => {
   const response = await axiosInstance
     .patch<APIResponse<UpdatedProjectMember>>(
-      `/projects/${projectId}/members/${memberId}/role`,
+      `/projects/${projectId}/members/${memberId}`,
       {
         role,
       }


### PR DESCRIPTION
This PR improves role-based access control in the Share Modal by ensuring that only Admins and Owners can modify project settings.

Key Changes:

Restricted Member Management:
- Only Admins & Owners can add, remove, or update roles of project members.
- Viewers & Editors can only see roles but cannot edit them.
- Owners cannot be removed by other roles.

Restricted General Access Settings:
- Only Admins & Owners can modify general access settings.
- Viewers & Editors can see but cannot update access settings.

Disabled Unauthorized Actions:
- Add Member button is hidden for non-Admins & non-Owners.
- Save button is only visible for Admins and Owners.
- General Access dropdowns are disabled for non-Admins & non-Owners.

Performance & UI Improvements:
- Optimized API calls to prevent redundant fetching when reopening the modal.