### PR TITLE
feat: Integrate Settings API

### DIFF
--- a/src/data/api/settingsApi.ts
+++ b/src/data/api/settingsApi.ts
@@ -1,0 +1,32 @@
+import axiosInstance from "../../utils/axiosInstance";
+import { APIResponse } from "../../types/APITypes";
+import { IUserSettings } from "../../store/useSettingsStore";
+
+export const getSettingsApi = async (userId: string) => {
+  const response = await axiosInstance
+    .get<APIResponse<{ settings: IUserSettings }>>(`/users/${userId}/settings`)
+    .then((res) => res.data);
+
+  return response;
+};
+
+export const updateSettingsApi = async (
+  userId: string,
+  settings: IUserSettings
+) => {
+  try {
+    const response = await axiosInstance
+      .patch<APIResponse<{ updatedSettings: IUserSettings }>>(
+        `/users/${userId}/settings`,
+        settings
+      )
+      .then((res) => res.data);
+
+    console.log("API Response:", response);
+
+    return response;
+  } catch (error) {
+    console.error("API Error updating settings:", error);
+    throw error;
+  }
+};

--- a/src/data/repo/useDataInitializer.ts
+++ b/src/data/repo/useDataInitializer.ts
@@ -9,11 +9,13 @@ import { getProjectsApi } from "../api/projectsApi";
 import { useIsFirstRender } from "@mantine/hooks";
 import useUserRepo from "./useUserRepo";
 import useChangelogRepo from "./useChangelogRepo";
+import { useSettingsRepo } from "./useSettingsRepo";
 
 export const useDataInitializer = () => {
   const { user } = useUserRepo();
   const { setProjectList, selectProject } = useProjectRepo();
   const { loadChangelogs } = useChangelogRepo();
+  const { fetchUserSettings } = useSettingsRepo();
 
   // Router
   const params = useParams();
@@ -27,7 +29,7 @@ export const useDataInitializer = () => {
   const [isLoaded, setIsLoaded] = useState<boolean>(false);
 
   useEffect(() => {
-    Promise.all([loadProjects(), loadEmojis()]).then(() => {
+    Promise.all([loadProjects(), loadEmojis(), loadUserSettings()]).then(() => {
       setIsLoaded(true);
     });
   }, []);
@@ -74,6 +76,12 @@ export const useDataInitializer = () => {
     return fetchEmojis().then((data) => {
       setEmojisDB(data);
     });
+  };
+
+  const loadUserSettings = async () => {
+    console.log("Loading user settings from server");
+    if (!user) return;
+    await fetchUserSettings(user.id);
   };
 
   return {

--- a/src/data/repo/useSettingsRepo.ts
+++ b/src/data/repo/useSettingsRepo.ts
@@ -1,0 +1,56 @@
+import { getSettingsApi, updateSettingsApi } from "../api/settingsApi";
+import { IUserSettings, useSettingsStore } from "../../store/useSettingsStore";
+import { BackgroundVariant } from "@xyflow/react";
+
+export const useSettingsRepo = () => {
+  const { settings, setSettings, updateSettings } = useSettingsStore();
+
+  const fetchUserSettings = async (userId: string) => {
+    try {
+      const response = await getSettingsApi(userId);
+      if (response.success) {
+        setSettings(response.data.settings);
+        return response.data.settings;
+      } else {
+        console.error("Failed to fetch settings:", response.message);
+      }
+    } catch (error) {
+      console.error("Error fetching settings:", error);
+    }
+  };
+
+  const updateUserSettings = async (
+    userId: string,
+    updatedSettings: IUserSettings
+  ) => {
+    try {
+      if (!settings) return;
+
+      const response = await updateSettingsApi(userId, updatedSettings);
+      if (response.success) {
+        setSettings(response.data.updatedSettings);
+      } else {
+        console.error("Failed to update settings:", response.message);
+      }
+    } catch (error) {
+      console.error("Error updating settings:", error);
+    }
+  };
+
+  const getCanvasBackground = () => {
+    const canvasBg = settings?.canvasBackground || "Dots";
+
+    return (
+      BackgroundVariant[canvasBg as keyof typeof BackgroundVariant] ||
+      BackgroundVariant.Dots
+    );
+  };
+
+  return {
+    settings,
+    fetchUserSettings,
+    updateUserSettings,
+    updateSettings,
+    getCanvasBackground,
+  };
+};

--- a/src/pages/editor/index.tsx
+++ b/src/pages/editor/index.tsx
@@ -22,7 +22,7 @@ import { useCallback, useMemo, useRef } from "react";
 import useEditorRepo from "../../data/repo/useEditorRepo";
 import { useEditorStore } from "../../store/useEditorStore";
 import NoteNode from "./nodes/NoteNode";
-import { usePartialUserSettingsStore } from "../../store/globalStore";
+import { useSettingsRepo } from "../../data/repo/useSettingsRepo";
 
 function Editor() {
   const nodeTypes: NodeTypes = useMemo(
@@ -39,8 +39,10 @@ function Editor() {
 
   const theme = useMantineTheme();
   const isDarkMode = useIsDarkMode();
-  const { canvasBackground } = usePartialUserSettingsStore();
-  const { screenToFlowPosition } = useReactFlow()
+  const { getCanvasBackground } = useSettingsRepo();
+  const canvasBackground = getCanvasBackground();
+
+  const { screenToFlowPosition } = useReactFlow();
 
   const nodes = useEditorStore((state) => state.nodes);
   const edges = useEditorStore((state) => state.edges);
@@ -73,15 +75,13 @@ function Editor() {
     []
   );
 
-  const onPaneClick = useCallback(
-    (event: React.MouseEvent) => {
-      const position = screenToFlowPosition({
-        x: event.clientX,
-        y: event.clientY,
-      })
-      console.log(position)
-    }, []
-  )
+  const onPaneClick = useCallback((event: React.MouseEvent) => {
+    const position = screenToFlowPosition({
+      x: event.clientX,
+      y: event.clientY,
+    });
+    console.log(position);
+  }, []);
 
   const { moveNode, addEdge, changeEdge, deleteEdge } = useEditorRepo();
 
@@ -107,7 +107,7 @@ function Editor() {
       >
         <Background
           color={!isDarkMode ? theme.colors.dark[9] : theme.colors.dark[4]}
-          variant={canvasBackground}
+          variant={canvasBackground as BackgroundVariant}
           gap={40}
         />
         <Controls />

--- a/src/store/useSettingsStore.ts
+++ b/src/store/useSettingsStore.ts
@@ -1,0 +1,37 @@
+import { create } from "zustand";
+import { devtools } from "zustand/middleware";
+import { BackgroundVariant } from "@xyflow/react";
+
+export interface IUserSettings {
+  autoSaveInterval: number;
+  canvasBackground: BackgroundVariant;
+  theme: "System" | "Light" | "Dark";
+}
+
+interface ISettingsState {
+  settings: IUserSettings | null;
+}
+
+interface ISettingsActions {
+  setSettings: (settings: IUserSettings) => void;
+  updateSettings: <K extends keyof IUserSettings>(
+    key: K,
+    value: IUserSettings[K]
+  ) => void;
+}
+
+export const useSettingsStore = create<ISettingsState & ISettingsActions>()(
+  devtools(
+    (set) => ({
+      settings: null,
+
+      setSettings: (settings) => set({ settings }),
+
+      updateSettings: (key, value) =>
+        set((state) => ({
+          settings: state.settings ? { ...state.settings, [key]: value } : null,
+        })),
+    }),
+    { name: "settingsStore" }
+  )
+);


### PR DESCRIPTION
This PR introduces updates below

- Created a new API for fetching and updating user settings from the server.
- Added a store for managing and maintaining user settings within the app.
- Incorporated user settings fetching into the data initialization process for seamless startup.
- Updated the settings modal to fetch user settings from the server
- Integrated the useSettingsRepo hook within the editor page to load and apply the user’s preferred canvas background dynamically.