### PR TITLE
FEAT: Member Modal, Code Gen, and Toolbar Changes

### DIFF
--- a/src/components/modals/CodeGenModal.tsx
+++ b/src/components/modals/CodeGenModal.tsx
@@ -1,11 +1,10 @@
-import { Box, Button, Code, CopyButton, ScrollArea, Tabs, Text } from "@mantine/core"
+import { Box, Button, CopyButton, Tabs, Text } from "@mantine/core"
 import { ContextModalProps } from "@mantine/modals"
 import { IconClipboard, IconClipboardCheck } from "@tabler/icons-react";
 import { useEffect } from "react";
 import SyntaxHighlighter from 'react-syntax-highlighter'
 import { atomOneDark } from "react-syntax-highlighter/dist/esm/styles/hljs";
 import useCodeGenRepo from "../../data/repo/useCodeGenRepo";
-import useEditorRepo from "../../data/repo/useEditorRepo";
 import { useEditorStore } from "../../store/useEditorStore";
 
 
@@ -31,10 +30,17 @@ function CodeGenModal({ context, id, innerProps }: ContextModalProps) {
           <Tabs.Tab value="types">
             Types
           </Tabs.Tab>
+          <Tabs.Tab value="functions">
+            Functions
+          </Tabs.Tab>
         </Tabs.List>
 
         <Tabs.Panel className="overflow-hidden" flex={1}  value="types">
           <TypesPanel />
+        </Tabs.Panel>
+
+        <Tabs.Panel className="overflow-hidden" flex={1}  value="functions">
+          <FunctionsPanel />
         </Tabs.Panel>
 
       </Tabs>
@@ -47,7 +53,7 @@ function TypesPanel() {
 
   const getDataSnap = useEditorStore((state) => state.getDataSnapshot);
 
-  const { typeString, typesList, selectType} = useCodeGenRepo(getDataSnap())
+  const { typeString, typesList, selectTable} = useCodeGenRepo(getDataSnap())
 
   return(
     <>
@@ -55,12 +61,12 @@ function TypesPanel() {
 
         <Tabs className="h-full" variant="pills" orientation="vertical" placement="right" radius='md' defaultValue='all'>
           <Tabs.List>
-            <Tabs.Tab value="all" onClick={()=>selectType(undefined)}>
+            <Tabs.Tab value="all" onClick={()=>selectTable(undefined)}>
               All
             </Tabs.Tab>
             {
               typesList.map((item)=>(
-                <Tabs.Tab key={item} value={item} onClick={()=>selectType(item)}>
+                <Tabs.Tab key={item} value={item} onClick={()=>selectTable(item)}>
                   {item}
                 </Tabs.Tab>
               ))
@@ -97,6 +103,72 @@ function TypesPanel() {
                 style={atomOneDark}
               >
                 {typeString}
+              </SyntaxHighlighter>
+            </Box>
+
+          </Box>
+
+        </Tabs>
+
+      </Box>
+    </>
+  )
+}
+
+function FunctionsPanel() {
+
+  const getDataSnap = useEditorStore((state) => state.getDataSnapshot);
+
+  const { functionString, typesList, selectTable} = useCodeGenRepo(getDataSnap())
+
+  return(
+    <>
+      <Box className="h-full p-4 border-[1px] border-t-0 border-neutral-500 border-opacity-25 rounded-b-md">
+
+        <Tabs className="h-full" variant="pills" orientation="vertical" placement="right" radius='md' defaultValue='all'>
+          <Tabs.List>
+            <Tabs.Tab value="all" onClick={()=>selectTable(undefined)}>
+              All
+            </Tabs.Tab>
+            {
+              typesList.map((item)=>(
+                <Tabs.Tab key={item} value={item} onClick={()=>selectTable(item)}>
+                  {item}
+                </Tabs.Tab>
+              ))
+            }
+          </Tabs.List>
+
+          <Box className="mr-4 flex-grow overflow-hidden">
+            
+            <Box className="h-full w-full relative rounded-md overflow-hidden">
+
+              <Box className="absolute top-2 right-6">
+                <CopyButton timeout={2000} value={functionString} >
+                  {({ copied, copy }) => (
+                    <Button 
+                      size="xs" 
+                      variant="light"
+                      leftSection={ copied ? <IconClipboardCheck size={16}/> : <IconClipboard size={16}/>} 
+                      onClick={copy}
+                    >
+                      {copied ? 'Copied' : 'Copy'}
+                    </Button>
+                  )}
+                </CopyButton>
+              </Box>
+              
+              <SyntaxHighlighter 
+                customStyle={{
+                  width: '100%',
+                  height: '100%',
+                  overflow: 'auto',
+                  fontSize: 14,
+                }} 
+                language="typescript" 
+                style={atomOneDark}
+              >
+                {functionString}
               </SyntaxHighlighter>
             </Box>
 

--- a/src/components/ui/TooltipIconButton.tsx
+++ b/src/components/ui/TooltipIconButton.tsx
@@ -1,0 +1,35 @@
+import { ActionIcon, ActionIconProps, Tooltip } from "@mantine/core";
+import { ReactNode } from "react";
+
+
+interface TooltipIconButtonProps extends ActionIconProps{
+  icon: ReactNode;
+  label: string;
+  disabled?: boolean;
+  active?: boolean;
+  onClick?: () => void;
+}
+
+export default function TooltipIconButton({
+  icon,
+  label,
+  disabled,
+  active,
+  onClick,
+  ...iconProps
+}: TooltipIconButtonProps) {
+  return (
+    <Tooltip label={label}>
+      <ActionIcon
+        {...iconProps}
+        variant={ active ? "filled" : iconProps.variant || "subtle"}
+        size={iconProps.size || "md"}
+        radius={iconProps.radius || "sm"}
+        disabled={disabled}
+        onClick={onClick}
+      >
+        {icon}
+      </ActionIcon>
+    </Tooltip>
+  );
+}

--- a/src/css/react-flow.css
+++ b/src/css/react-flow.css
@@ -1,0 +1,4 @@
+
+.react-flow.cursor-cross .react-flow__pane {
+	cursor: crosshair; /* add !important if necessary */
+}

--- a/src/data/repo/useToolbarRepo.ts
+++ b/src/data/repo/useToolbarRepo.ts
@@ -1,0 +1,26 @@
+import { ToolbarOptions, useToolbarStore } from "../../store/useToolbarStore";
+
+
+const useToolbarRepo = () => {
+  const setCurrentTool = useToolbarStore((state) => state.setCurrentTool);
+
+  const changeTool = (tool: ToolbarOptions) => {
+    setCurrentTool(tool)
+  }
+
+  const resetTool = () => {
+    setCurrentTool("select")
+  }
+
+  const onTableClick = () => {
+    
+  }
+
+  return {
+    changeTool,
+    resetTool
+  }
+}
+
+
+export default useToolbarRepo

--- a/src/layouts/BottomMiddleBar.tsx
+++ b/src/layouts/BottomMiddleBar.tsx
@@ -1,20 +1,23 @@
-import { ActionIcon, Box, Flex, Paper } from "@mantine/core";
+import { Box, Flex, Paper } from "@mantine/core";
 import {
   IconNote,
   IconPointerFilled,
   IconTableFilled,
 } from "@tabler/icons-react";
 import useIsDarkMode from "../hooks/useIsDarkMode";
-import useEditorRepo from "../data/repo/useEditorRepo";
 import useProjectRepo from "../data/repo/useProjectRepo";
+import TooltipIconButton from "../components/ui/TooltipIconButton";
+import { useToolbarStore } from "../store/useToolbarStore";
+import useToolbarRepo from "../data/repo/useToolbarRepo";
 
 function BottomMiddleBar() {
   const isDarkMode = useIsDarkMode();
-  const { selectedProject } = useProjectRepo();
 
+  const { selectedProject } = useProjectRepo();
   const isButtonDisabled = !selectedProject;
 
-  const { addNode } = useEditorRepo();
+  const currentTool = useToolbarStore(state => state.currentTool)
+  const { changeTool } = useToolbarRepo()
 
   return (
     <Box className="p-3.5 absolute z-10 bottom-0 left-1/2 transform -translate-x-1/2">
@@ -27,26 +30,27 @@ function BottomMiddleBar() {
           wrap="wrap"
         >
           <Flex className="gap-1" direction="row" wrap="wrap">
-            <ActionIcon variant="subtle" size="md" radius="sm">
-              <IconPointerFilled className="p-0.5" />
-            </ActionIcon>
-            <ActionIcon
+            <TooltipIconButton
+              label="Select"
+              icon={<IconPointerFilled className="p-0.5" />}
+              variant="subtle" size="md" radius="sm"
+              active={currentTool == "select"}
+              onClick={() => changeTool("select")}
+            />
+            <TooltipIconButton
+              label="Table"
+              icon={<IconTableFilled className="p-0.5" />}
               variant="subtle"
               size="md"
               radius="sm"
-              onClick={() => addNode("table")}
               disabled={isButtonDisabled}
-            >
-              <IconTableFilled className="p-0.5" />
-            </ActionIcon>
-            <ActionIcon
-              variant="subtle"
-              size="md"
-              radius="sm"
-              onClick={() => addNode("note")}
-              disabled={isButtonDisabled}
-            >
-              <IconNote
+              active={currentTool == "table"}
+              onClick={() => changeTool("table")}
+            />
+            <TooltipIconButton
+              label="Note"
+              icon={
+                <IconNote
                 className="p-0.5"
                 fill={
                   isButtonDisabled
@@ -59,7 +63,14 @@ function BottomMiddleBar() {
                 }
                 stroke={1.5}
               />
-            </ActionIcon>
+              }
+              variant="subtle"
+              size="md"
+              radius="sm"
+              disabled={isButtonDisabled}
+              active={currentTool == "note"}
+              onClick={() => changeTool("note")}
+            />
           </Flex>
         </Flex>
       </Paper>

--- a/src/layouts/TopLeftBar.tsx
+++ b/src/layouts/TopLeftBar.tsx
@@ -14,10 +14,8 @@ import {
   useViewportSize,
 } from "@mantine/hooks";
 import { modals } from "@mantine/modals";
-import { notifications } from "@mantine/notifications";
 import {
   IconArrowBackUp,
-  IconCopy,
   IconDeviceFloppy,
   IconDots,
   IconEdit,
@@ -28,7 +26,6 @@ import {
   IconX,
 } from "@tabler/icons-react";
 import { useNavigate, useParams } from "react-router-dom";
-import { StatusIcon } from "../components/icons/StatusIcon";
 import ConditionalHoverCard from "../components/ui/ConditionalHoverCard";
 import useChangelogRepo from "../data/repo/useChangelogRepo";
 import useHistoryRepo from "../data/repo/useHistoryRepo";
@@ -41,10 +38,9 @@ import { useEditorStore } from "../store/useEditorStore";
 import { IProject } from "../types/ProjectTypes";
 import { DrawerModalFormValues } from "../types/TopLeftBarTypes";
 import { determineTitle } from "../utils/successHelpers";
-import useMemberRepo from "../data/repo/useMemberRepo";
-import { useMemberStore } from "../store/useMemberStore";
 import CustomNotification from "../components/ui/CustomNotification";
 import { APIResponse, SavedProject } from "../types/APITypes";
+import TooltipIconButton from "../components/ui/TooltipIconButton";
 
 function TopLeftBar() {
   const [drawerLocalStorage, setDrawerLocalStorage] = useLocalStorage({
@@ -122,41 +118,47 @@ function ActionButtons({
       direction={width < 900 ? "column" : "row"}
       wrap="wrap"
     >
-      <ActionIcon variant="subtle" size="lg" radius="xl" onClick={toggleDrawer}>
-        {openedDrawer ? <IconX /> : <IconMenu2 />}
-      </ActionIcon>
-      <ActionIcon
+      <TooltipIconButton
+        label="Menu"
+        icon={openedDrawer ? <IconX /> : <IconMenu2 />}
+        variant="subtle" size="lg" radius="xl" onClick={toggleDrawer}
+      />
+      <TooltipIconButton
+        label="Undo"
+        icon={<IconArrowBackUp />}
         variant="subtle"
         size="lg"
         radius="xl"
         onClick={onUndo}
         disabled={!canUndo}
-      >
-        <IconArrowBackUp />
-      </ActionIcon>
-      <ActionIcon
+      />
+      <TooltipIconButton
+        label="Redo"
+        icon={
+          <IconArrowBackUp
+          style={{
+            transform: "scaleX(-1)",
+          }}
+        />
+        }
         variant="subtle"
         size="lg"
         radius="xl"
         onClick={onRedo}
         disabled={!canRedo}
-      >
-        <IconArrowBackUp
-          style={{
-            transform: "scaleX(-1)",
-          }}
-        />
-      </ActionIcon>
-      <ActionIcon
+      />
+      <TooltipIconButton
+        label="Save"
+        icon={hasPendingChanges ? <Loader size={"sm"} /> : <IconDeviceFloppy />}
         variant="subtle"
         size="lg"
         radius="xl"
         onClick={() => handleSave()}
         disabled={!validateRole()}
-      >
-        {hasPendingChanges ? <Loader size={"sm"} /> : <IconDeviceFloppy />}
-      </ActionIcon>
-      <ActionIcon
+      />
+      <TooltipIconButton
+        label="Settings"
+        icon={<IconSettings />}
         variant="subtle"
         size="lg"
         radius="xl"
@@ -166,9 +168,7 @@ function ActionButtons({
             innerProps: {},
           })
         }
-      >
-        <IconSettings />
-      </ActionIcon>
+      />
     </Flex>
   );
 }

--- a/src/layouts/TopMiddleBar.tsx
+++ b/src/layouts/TopMiddleBar.tsx
@@ -1,30 +1,25 @@
 import {
-  ActionIcon,
   Box,
   Divider,
   Flex,
-  HoverCard,
   Paper,
   rem,
   Text,
-  Tooltip,
 } from "@mantine/core";
 import {
   IconCode,
   IconDownload,
-  IconSchool,
   IconShare,
-  IconTool,
 } from "@tabler/icons-react";
 import { useProjectStore } from "../store/useProjectStore";
 import useProjectIcon from "../hooks/useProjectIcon";
 import ConditionalHoverCard from "../components/ui/ConditionalHoverCard";
 import useIsTruncated from "../hooks/useIsTruncated";
-import { ReactNode } from "react";
 import { modals } from "@mantine/modals";
 import useCodeGenRepo from "../data/repo/useCodeGenRepo";
 import { useEditorStore } from "../store/useEditorStore";
 import CustomNotification from "../components/ui/CustomNotification";
+import TooltipIconButton from "../components/ui/TooltipIconButton";
 
 function TopMiddleBar() {
   const { selectedProject } = useProjectStore();
@@ -72,7 +67,7 @@ function TopMiddleBar() {
     <Box
       className="p-3.5 absolute z-10 top-0 left-1/2 transform -translate-x-1/2"
       maw={rem(340)}
-      miw={rem(337)}
+      miw={rem(310)}
     >
       <Paper>
         <Flex
@@ -100,11 +95,11 @@ function TopMiddleBar() {
 
           <Divider orientation="vertical" />
           <Flex className="gap-1" direction="row" wrap="wrap">
-            <TooltipIconButton
+            {/* <TooltipIconButton
               icon={<IconTool className="p-0.5" />}
               label="Initial Setup"
               disabled={isButtonDisabled}
-            />
+            /> */}
             <TooltipIconButton
               icon={<IconCode className="p-0.5" />}
               label="Code Generation"
@@ -132,32 +127,6 @@ function TopMiddleBar() {
         </Flex>
       </Paper>
     </Box>
-  );
-}
-
-function TooltipIconButton({
-  icon,
-  label,
-  disabled,
-  onClick,
-}: {
-  icon: ReactNode;
-  label: string;
-  disabled: boolean;
-  onClick?: () => void;
-}) {
-  return (
-    <Tooltip label={label}>
-      <ActionIcon
-        variant="subtle"
-        size="md"
-        radius="sm"
-        disabled={disabled}
-        onClick={onClick}
-      >
-        {icon}
-      </ActionIcon>
-    </Tooltip>
   );
 }
 

--- a/src/layouts/TopRightBar.tsx
+++ b/src/layouts/TopRightBar.tsx
@@ -1,5 +1,4 @@
 import {
-  ActionIcon,
   Avatar,
   Box,
   Button,
@@ -29,11 +28,10 @@ import useUserRepo from "../data/repo/useUserRepo";
 import useChangelogRepo from "../data/repo/useChangelogRepo";
 import { IChangelog, IMember } from "../store/useChangelogStore";
 import useProjectRepo from "../data/repo/useProjectRepo";
-import useEditorRepo from "../data/repo/useEditorRepo";
-import { IProject } from "../types/ProjectTypes";
 import { IEditorDataSnapshot } from "../types/EditorStoreTypes";
 import { useNavigate } from "react-router-dom";
 import ProfileAvatar from "../components/ui/ProfileAvatar";
+import TooltipIconButton from "../components/ui/TooltipIconButton";
 
 function TopRightBar() {
   const [drawerOpen, setDrawerOpen] = useState(false);
@@ -97,15 +95,15 @@ function ActionButtons({
       direction={width < 900 ? "column" : "row"}
       wrap="wrap"
     >
-      <ActionIcon
+      <TooltipIconButton
+        label="Version History"
+        icon={openedDrawer ? <IconHistoryToggle /> : <IconHistory />}
         variant="subtle"
         size="lg"
         radius="xl"
         onClick={toggleDrawer}
         disabled={isButtonDisabled}
-      >
-        {openedDrawer ? <IconHistoryToggle /> : <IconHistory />}
-      </ActionIcon>
+      />
       <Popover
         position="bottom-end"
         width={300}

--- a/src/pages/editor/index.tsx
+++ b/src/pages/editor/index.tsx
@@ -23,12 +23,14 @@ import useEditorRepo from "../../data/repo/useEditorRepo";
 import { useEditorStore } from "../../store/useEditorStore";
 import NoteNode from "./nodes/NoteNode";
 import { useSettingsRepo } from "../../data/repo/useSettingsRepo";
-import useMemberRepo from "../../data/repo/useMemberRepo";
-import { useMemberStore } from "../../store/useMemberStore";
 import useProjectRepo from "../../data/repo/useProjectRepo";
+import { useToolbarStore } from "../../store/useToolbarStore";
+import useToolbarRepo from "../../data/repo/useToolbarRepo";
+import "../../css/react-flow.css"
+
 
 function Editor() {
-  const { moveNode, addEdge, changeEdge, deleteEdge } = useEditorRepo();
+  const { moveNode, addNode, addEdge, changeEdge, deleteEdge } = useEditorRepo();
   const { validateRole } = useProjectRepo()
   //const { currentProjectAccess } = useMemberStore()
   
@@ -53,6 +55,9 @@ function Editor() {
 
   const nodes = useEditorStore((state) => state.nodes);
   const edges = useEditorStore((state) => state.edges);
+
+  const currentTool = useToolbarStore(state => state.currentTool)
+  const { resetTool } = useToolbarRepo()
 
   const onNodeDrag: OnNodeDrag<EditorNode> = useCallback(
     (_, node) => {
@@ -87,11 +92,19 @@ function Editor() {
 
   const onPaneClick = useCallback((event: React.MouseEvent) => {
     const position = screenToFlowPosition({
-      x: event.clientX,
-      y: event.clientY,
+      x: event.clientX + -50,
+      y: event.clientY + -50,
     });
-    console.log(position);
-  }, [useEditorRepo()]);
+
+    console.log(position)
+    if(currentTool == "table") {
+      addNode("table", position);
+    } else if (currentTool == "note") {
+      addNode("note", position);
+    }
+
+    resetTool();
+  }, [useEditorRepo(), currentTool]);
 
 
   return (
@@ -112,7 +125,7 @@ function Editor() {
         onPaneClick={onPaneClick}
         proOptions={proOptions}
         connectionMode={ConnectionMode.Loose}
-        className="-z-10"
+        className={`-z-10 ${currentTool !== "select" ? "cursor-cross": ""}`}
         nodesDraggable={validateRole()}
         nodesConnectable={validateRole()}
         nodesFocusable={validateRole()}

--- a/src/store/useToolbarStore.ts
+++ b/src/store/useToolbarStore.ts
@@ -1,0 +1,27 @@
+import { create } from "zustand";
+import { devtools } from "zustand/middleware";
+
+
+export type ToolbarOptions = "select" | "table" | "note"
+
+interface IToolbarState {
+  currentTool: ToolbarOptions;
+}
+
+interface IToolbarActions {
+  setCurrentTool: (option: ToolbarOptions) => void;
+}
+
+
+export const useToolbarStore = create<IToolbarState & IToolbarActions>()(
+  devtools(
+    (set) => ({
+      currentTool: "select",
+
+      setCurrentTool: (option) => set(() => ({ currentTool: option })),
+    }),
+    {
+      name: "toolbarStore",
+    }
+  )
+);


### PR DESCRIPTION
- Added dimming style for members added in the local state
- Made the save button conditional in Share Modal
- Added tooltips for the rest of the panel icon buttons
- Removed initial setup button
- Added new tab and code gen logic for the Code Generation modal
- Implemented appending of target id when connecting table nodes
- Implemented toolbar switching
- Reworked the adding of nodes to now add on mouse click position