### PR TITLE
Add Home Docker Compose, Adjust Home Production Traefik Entrypoint, and Update Static Traefik Config

### DIFF
--- a/server/compose.home.yml
+++ b/server/compose.home.yml
@@ -1,0 +1,114 @@
+services: 
+
+  # To prevent mounting docker.sock, which is a security risk
+  socket-proxy:
+    image: tecnativa/docker-socket-proxy
+    environment:
+      CONTAINERS: 1
+    volumes:
+    - /var/run/docker.sock:/var/run/docker.sock
+    networks:
+    - socket-proxy-network
+
+  reverse-proxy:
+    image: traefik:latest
+    command:
+    - "--configFile=/etc/traefik/config/static.yml"
+    security_opt:
+    - no-new-privileges:true
+    ports:
+    - "80:80"
+    - "443:443"
+    - "3000:3000"
+    volumes:
+    - ./letsencrypt:/letsencrypt:rw # letsencrypt folder
+    - ./traefik/config:/etc/traefik/config:ro # traefik folder
+    - ./traefik/logs:/logs # traefik folder
+    environment:
+      BASE_URL_FQDN: ${BASE_URL_FQDN}
+      CLIENT_URL: ${CLIENT_URL}
+    restart: always
+    networks:
+    - server-network
+    - socket-proxy-network
+    depends_on:
+    - socket-proxy
+
+  mongo:
+    image: mongo:latest
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: ${MONGO_USERNAME}
+      MONGO_INITDB_ROOT_PASSWORD: ${MONGO_PASSWORD}
+      MONGO_INITDB_DATABASE: FERD
+      INIT_MONGO_USERNAME: ${MONGO_USERNAME}
+      INIT_MONGO_PASSWORD: ${MONGO_PASSWORD}
+      INIT_MONGO_DATABASE: FERD
+    volumes:
+    - ./mongodb-data:/data/db
+    - ./mongo-init.js:/docker-entrypoint-initdb.d/mongo-init.js:ro
+    restart: always
+    networks:
+    - server-network
+  
+  server:
+    image: ghcr.io/morfusee/ferd-server:latest
+    environment:
+      SESSION_KEY: ${SESSION_KEY}
+      SERVICE_ACCOUNT: ${SERVICE_ACCOUNT}
+      GOOGLE_CLIENT_ID: ${GOOGLE_CLIENT_ID}
+      GOOGLE_CLIENT_SECRET: ${GOOGLE_CLIENT_SECRET}
+      CLIENT_URL: ${CLIENT_URL}
+      BASE_URL: ${BASE_URL}
+      MONGO_DOCKER_URI: ${MONGO_DOCKER_URI}
+      IS_DOCKERIZED: true
+    labels:
+    # Since you have two replicas, you can't put all of these inside dynamic.yml :(
+    # Enable Traefik for this service
+    - "traefik.enable=true"
+
+    # Router Configuration
+    - "traefik.http.routers.server.rule=Host(`api.ferd.mcube.uk`)"
+    - "traefik.http.routers.server.entrypoints=web"
+
+    # Auto update image
+    - "com.centurylinklabs.watchtower.enable=true"
+    restart: always
+    networks:
+    - server-network
+    deploy:
+      mode: replicated
+      replicas: 2
+    depends_on:
+    - mongo
+
+  watchtower:
+    image: containrrr/watchtower
+    command:
+    - "--label-enable"
+    - "--interval"
+    - "30"
+    - "--rolling-restart"
+    environment:
+      WATCHTOWER_CLEANUP: true
+    volumes:
+    - /var/run/docker.sock:/var/run/docker.sock
+    restart: always
+    
+  # cloudflared:
+  #   image: cloudflare/cloudflared:latest
+  #   restart: unless-stopped
+  #   command: tunnel --no-autoupdate run
+  #   environment:
+  #     TUNNEL_TOKEN: ${TUNNEL_TOKEN}
+  #   networks: # This should be set to enable http://server:3000 as a URL
+  #   - server-network
+
+networks:
+  server-network:
+    driver: bridge
+  socket-proxy-network:
+    driver: bridge
+
+# When reusing this compose file, please create the following folders:
+# - letsencrypt
+# - traefik

--- a/server/compose.prod.yml
+++ b/server/compose.prod.yml
@@ -19,6 +19,7 @@ services:
     ports:
     - "80:80"
     - "443:443"
+    - "3000:3000"
     volumes:
     - ./letsencrypt:/letsencrypt:rw # letsencrypt folder
     - ./traefik/config:/etc/traefik/config:ro # traefik folder
@@ -66,16 +67,17 @@ services:
     - "traefik.enable=true"
 
     # Router Configuration
-    - "traefik.http.routers.server.rule=Host(`${BASE_URL_FQDN}`)"
-    - "traefik.http.routers.server.entrypoints=websecure"
+    # - "traefik.http.routers.server.rule=Host(`${BASE_URL_FQDN}`)"
+    - "traefik.http.routers.server.rule=PathPrefix(`/`)"
+    - "traefik.http.routers.server.entrypoints=server"
     - "traefik.http.routers.server.middlewares=cors,security,block-sensitive"
-    - "traefik.http.routers.server.tls.certresolver=tlsresolver"
+    # - "traefik.http.routers.server.tls.certresolver=tlsresolver"
 
-    # TLS Configuration
-    - "traefik.tls.options.default.minVersion=VersionTLS12"
-    - "traefik.tls.options.default.sniStrict=true"
-    - "traefik.tls.options.default.cipherSuites=TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
-    - "traefik.tls.options.default.curvePreferences=CurveP521,CurveP384"
+    # # TLS Configuration
+    # - "traefik.tls.options.default.minVersion=VersionTLS12"
+    # - "traefik.tls.options.default.sniStrict=true"
+    # - "traefik.tls.options.default.cipherSuites=TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
+    # - "traefik.tls.options.default.curvePreferences=CurveP521,CurveP384"
 
     # Middleware: CORS Headers
     - "traefik.http.middlewares.cors.headers.accesscontrolallowmethods=GET,POST,PATCH,DELETE"
@@ -99,14 +101,16 @@ services:
     - "traefik.http.middlewares.block-sensitive.redirectregex.replacement=https://www.youtube.com/watch?v=xvFZjo5PgG0"
     - "traefik.http.middlewares.block-sensitive.redirectregex.permanent=true"
 
+    - "traefik.http.services.server.loadbalancer.server.port=3000"
+
     # Auto update image
     - "com.centurylinklabs.watchtower.enable=true"
     restart: always
     networks:
     - server-network
-    deploy:
-      mode: replicated
-      replicas: 2
+    # deploy:
+    #   mode: replicated
+    #   replicas: 2
     depends_on:
     - mongo
 

--- a/server/compose.prod.yml
+++ b/server/compose.prod.yml
@@ -19,7 +19,6 @@ services:
     ports:
     - "80:80"
     - "443:443"
-    - "3000:3000"
     volumes:
     - ./letsencrypt:/letsencrypt:rw # letsencrypt folder
     - ./traefik/config:/etc/traefik/config:ro # traefik folder
@@ -67,17 +66,16 @@ services:
     - "traefik.enable=true"
 
     # Router Configuration
-    # - "traefik.http.routers.server.rule=Host(`${BASE_URL_FQDN}`)"
-    - "traefik.http.routers.server.rule=PathPrefix(`/`)"
+    - "traefik.http.routers.server.rule=Host(`${BASE_URL_FQDN}`)"
     - "traefik.http.routers.server.entrypoints=server"
     - "traefik.http.routers.server.middlewares=cors,security,block-sensitive"
-    # - "traefik.http.routers.server.tls.certresolver=tlsresolver"
+    - "traefik.http.routers.server.tls.certresolver=tlsresolver"
 
-    # # TLS Configuration
-    # - "traefik.tls.options.default.minVersion=VersionTLS12"
-    # - "traefik.tls.options.default.sniStrict=true"
-    # - "traefik.tls.options.default.cipherSuites=TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
-    # - "traefik.tls.options.default.curvePreferences=CurveP521,CurveP384"
+    # TLS Configuration
+    - "traefik.tls.options.default.minVersion=VersionTLS12"
+    - "traefik.tls.options.default.sniStrict=true"
+    - "traefik.tls.options.default.cipherSuites=TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
+    - "traefik.tls.options.default.curvePreferences=CurveP521,CurveP384"
 
     # Middleware: CORS Headers
     - "traefik.http.middlewares.cors.headers.accesscontrolallowmethods=GET,POST,PATCH,DELETE"
@@ -101,16 +99,14 @@ services:
     - "traefik.http.middlewares.block-sensitive.redirectregex.replacement=https://www.youtube.com/watch?v=xvFZjo5PgG0"
     - "traefik.http.middlewares.block-sensitive.redirectregex.permanent=true"
 
-    - "traefik.http.services.server.loadbalancer.server.port=3000"
-
     # Auto update image
     - "com.centurylinklabs.watchtower.enable=true"
     restart: always
     networks:
     - server-network
-    # deploy:
-    #   mode: replicated
-    #   replicas: 2
+    deploy:
+      mode: replicated
+      replicas: 2
     depends_on:
     - mongo
 

--- a/server/traefik/config/static.yml
+++ b/server/traefik/config/static.yml
@@ -12,15 +12,13 @@ accessLog:
 entryPoints:
   web:
     address: ":80"
-    http:
-      redirections:
-        entryPoint:
-          to: websecure
-          scheme: https
+    # http:
+    #   redirections:
+    #     entryPoint:
+    #       to: websecure
+    #       scheme: https
   websecure:
     address: ":443"
-  server:
-    address: ":3000"
 
 providers:
   docker:

--- a/server/traefik/config/static.yml
+++ b/server/traefik/config/static.yml
@@ -19,6 +19,8 @@ entryPoints:
           scheme: https
   websecure:
     address: ":443"
+  server:
+    address: ":3000"
 
 providers:
   docker:


### PR DESCRIPTION
This pull request introduces several infrastructure and configuration improvements:

- **Add compose.home.yml:**
Introduces a new Docker Compose file for home/local development under server/compose.home.yml. This file sets up supporting services such as Traefik, MongoDB, a socket proxy, the server (with two replicas), and Watchtower for automated image updates. It also includes network definitions and environment variable configuration for local deployment.

- **Update Production Compose Entrypoint:**
Changes the Traefik router entrypoint in server/compose.prod.yml from websecure to server, aligning with the current deployment setup.

- **Adjust Traefik Static Configuration:**
Comments out the HTTP-to-HTTPS redirection in server/traefik/config/static.yml for the web entry point. This allows for more flexible local or custom deployments without forced HTTPS redirection.