### PR TITLE
CONF: Update Docker Build and Push Workflow with Dynamic Tagging and Improved Security Practices

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -4,24 +4,55 @@ on:
   push:
     branches:
       - "main"
-  pull_request:
-    branches:
-      - "main"
-  workflow_dispatch: # Allows manual triggering of the workflow
-    inputs:
-      tag:
-        description: "Tag for the Docker image"
-        required: false
-        default: "latest"
+      - "conf/*"
+  
+permissions:
+  packages: write
 
 jobs:
+  commit-hash:
+    runs-on: ubuntu-latest
+    outputs:
+      commit_hash: ${{ steps.get_commit_hash.outputs.commit_hash }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Get commit hash
+        id: get_commit_hash
+        run: echo "commit_hash=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+
   build:
     environment: Prod
     runs-on: ubuntu-latest
+    needs: commit-hash
+
     steps:
-      - uses: actions/checkout@v4
-      - name: Build and Push the Image
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set short git commit SHA
+        id: vars
         run: |
-          docker login --username Morfusee --password ${{ secrets.GH_PAT }} ghcr.io
-          docker build ./server --file ./server/Dockerfile --tag ghcr.io/morfusee/ferd-server:latest
-          docker push ghcr.io/morfusee/ferd-server:latest
+          calculatedSha=$(git rev-parse --short ${{ github.sha }})
+          echo "COMMIT_SHORT_SHA=$calculatedSha" >> $GITHUB_ENV
+
+      - name: Set lowercase repo owner
+        run: echo "REPO_OWNER_LC=${GITHUB_REPOSITORY_OWNER,,}" >> $GITHUB_ENV
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GH_PAT }}
+
+      - name: Build and Push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: ./server
+          file: ./server/Dockerfile
+          push: true
+          tags: |
+            ghcr.io/${{ env.REPO_OWNER_LC }}/ferd-server:${{ needs.commit-hash.outputs.commit_hash }}
+            ghcr.io/${{ env.REPO_OWNER_LC }}/ferd-server:latest

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - "main"
-      - "conf/*"
   
 permissions:
   packages: write


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for building and pushing Docker images. The main changes modernize and improve the workflow by introducing reusable steps, dynamic tagging, and enhanced security practices.

**Workflow improvements:**

* Added a separate `commit-hash` job to compute and output the short commit hash, allowing Docker images to be tagged with the current commit for better traceability.
* Replaced manual Docker build and push commands with the official `docker/build-push-action`, simplifying the process and ensuring best practices.
* Added steps to set environment variables for the short commit SHA and lowercase repository owner, improving consistency in image tagging.

**Security and configuration updates:**

* Updated Docker registry authentication to use the `docker/login-action` with GitHub Actions' built-in secrets and actor, improving security and maintainability.
* Set explicit `permissions` for the workflow to grant write access to packages, aligning with GitHub's security recommendations.