### PR TITLE
FIX: Implement email verification page fix

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -24,6 +24,7 @@
         "mongoose": "^8.10.1",
         "multer": "^1.4.4",
         "multer-gridfs-storage": "^5.0.2",
+        "node-cron": "^4.2.1",
         "passport": "^0.7.0",
         "passport-google-oauth20": "^2.0.0",
         "server": "file:",
@@ -7943,6 +7944,14 @@
       },
       "engines": {
         "node": ">=12.22.0"
+      }
+    },
+    "node_modules/node-cron": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/node-cron/-/node-cron-4.2.1.tgz",
+      "integrity": "sha512-lgimEHPE/QDgFlywTd8yTR61ptugX3Qer29efeyWw2rv259HtGBNn1vZVmp8lB9uo9wC0t/AT4iGqXxia+CJFg==",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/node-fetch": {

--- a/server/package.json
+++ b/server/package.json
@@ -27,6 +27,7 @@
     "mongoose": "^8.10.1",
     "multer": "^1.4.4",
     "multer-gridfs-storage": "^5.0.2",
+    "node-cron": "^4.2.1",
     "passport": "^0.7.0",
     "passport-google-oauth20": "^2.0.0",
     "server": "file:",

--- a/src/pages/email-verification/index.tsx
+++ b/src/pages/email-verification/index.tsx
@@ -105,8 +105,8 @@ function EmailVerification() {
           variant="filled"
           color={verified ? "green" : "blue"}
           onClick={() => {
-            navigate("/login");
             logoutUser();
+            navigate("/login");
           }}
         >
           Go to Login

--- a/src/pages/email-verification/index.tsx
+++ b/src/pages/email-verification/index.tsx
@@ -1,28 +1,57 @@
 import { Button, Center, Container, Loader, Stack, Text } from "@mantine/core";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { emailVerifiedStatusApi } from "../../data/api/authApi";
+import useUserRepo from "../../data/repo/useUserRepo";
+
+const EXPIRATION_HOURS = 24;
 
 function EmailVerification() {
   const [verified, setVerified] = useState(false);
+  const [expired, setExpired] = useState(false);
   const [loading, setLoading] = useState(true);
   const navigate = useNavigate();
+  const { user, logoutUser } = useUserRepo();
+  const pollCount = useRef(0);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const checkExpiration = (createdAt: string) => {
+    if (!createdAt) return false;
+    const ageMs = Date.now() - new Date(createdAt).getTime();
+    return ageMs > EXPIRATION_HOURS * 60 * 60 * 1000;
+  };
 
   const pollVerification = useCallback(async () => {
     try {
       const res = await emailVerifiedStatusApi();
-      if (res.data.emailVerified) setVerified(true);
+
+      if (user && checkExpiration(user.createdAt)) {
+        setExpired(true);
+        if (intervalRef.current) clearInterval(intervalRef.current);
+        return;
+      }
+
+      if (res.data.emailVerified) {
+        setVerified(true);
+        if (intervalRef.current) clearInterval(intervalRef.current);
+        return;
+      }
     } catch (err) {
       console.error("Polling failed", err);
     } finally {
       setLoading(false);
+      pollCount.current += 1;
+      if (pollCount.current > 60 && intervalRef.current)
+        clearInterval(intervalRef.current);
     }
   }, []);
 
   useEffect(() => {
     pollVerification();
-    const interval = setInterval(pollVerification, 5000);
-    return () => clearInterval(interval);
+    intervalRef.current = setInterval(pollVerification, 5000);
+    return () => {
+      if (intervalRef.current) clearInterval(intervalRef.current);
+    };
   }, [pollVerification]);
 
   useEffect(() => {
@@ -35,7 +64,16 @@ function EmailVerification() {
   return (
     <Container size="xs" mt="10%">
       <Stack align="center" gap="lg">
-        {!verified ? (
+        {expired ? (
+          <>
+            <Text size="xl" fw={600} c="red">
+              Email verification expired
+            </Text>
+            <Text ta="center" c="dimmed">
+              This verification link has expired. Please register again.
+            </Text>
+          </>
+        ) : !verified ? (
           <>
             <Text size="xl" fw={600}>
               Verify your email
@@ -62,10 +100,14 @@ function EmailVerification() {
             </Text>
           </>
         )}
+
         <Button
           variant="filled"
           color={verified ? "green" : "blue"}
-          onClick={() => navigate("/login")}
+          onClick={() => {
+            navigate("/login");
+            logoutUser();
+          }}
         >
           Go to Login
         </Button>

--- a/src/store/useUserStore.ts
+++ b/src/store/useUserStore.ts
@@ -8,6 +8,8 @@ export interface IUser {
   displayName?: string;
   profilePicture?: string;
   token: string;
+  createdAt: string;
+  updatedAt: string;
 }
 
 interface IUserState {
@@ -15,7 +17,7 @@ interface IUserState {
 }
 
 interface IUserActions {
-  getCurrentUser: () => IUser | null
+  getCurrentUser: () => IUser | null;
   setCurrentUser: (user: IUser | null) => void;
   setProfileImage: (image: string) => void;
 }


### PR DESCRIPTION
This pull request introduces an email verification expiration feature and makes some supporting dependency and type updates. The main change is that users will now see an expiration message if they try to verify their email after 24 hours, and will be prompted to register again. Additional improvements include cleaning up polling logic and updating user type definitions.

**Email Verification Expiration Feature:**

* Added logic in `EmailVerification` page to check if the verification link has expired (after 24 hours from user creation) and display an appropriate message if so. The polling for verification status now also stops if the link is expired. (`src/pages/email-verification/index.tsx`) [[1]](diffhunk://#diff-58713555885a6a7d0c83263a7211ae52900a9efde5e03d266d7946b4e85a2fc2L2-R54) [[2]](diffhunk://#diff-58713555885a6a7d0c83263a7211ae52900a9efde5e03d266d7946b4e85a2fc2L38-R76)
* Updated the "Go to Login" button to also log out the user when clicked, ensuring a clean state if verification fails or expires. (`src/pages/email-verification/index.tsx`)

**User Type and Store Updates:**

* Added `createdAt` and `updatedAt` fields to the `IUser` interface to support expiration logic. (`src/store/useUserStore.ts`)

**Dependency Management:**

* Added the `node-cron` package to dependencies and lock files, preparing for possible future scheduled tasks. (`server/package.json`, `server/package-lock.json`) [[1]](diffhunk://#diff-da00458cdaeaea2314cb0e0101c85130593048072ada62de01727958c5d6ca37R30) [[2]](diffhunk://#diff-be330df323f72d45d073e311befe92984fad9846bb7e982261d702d805c14053R27) [[3]](diffhunk://#diff-be330df323f72d45d073e311befe92984fad9846bb7e982261d702d805c14053R7949-R7956)